### PR TITLE
maxUploadSpeed: Introduce upload speed limit.

### DIFF
--- a/inc/libs3.h
+++ b/inc/libs3.h
@@ -2054,6 +2054,7 @@ void S3_list_bucket(const S3BucketContext *bucketContext,
  *        request to, and does not perform the request immediately.  If NULL,
  *        performs the request immediately and synchronously.
  * @param timeoutMs if not 0 contains total request timeout in milliseconds
+ * @param maxUploadSpeed if not 0, set the max upload speed of the request in byte / sec
  * @param handler gives the callbacks to call as the request is processed and
  *        completed
  * @param callbackData will be passed in as the callbackData parameter to
@@ -2063,7 +2064,7 @@ void S3_put_object(const S3BucketContext *bucketContext, const char *key,
                    uint64_t contentLength,
                    const S3PutProperties *putProperties,
                    S3RequestContext *requestContext,
-                   int timeoutMs,
+                   int timeoutMs, int maxUploadSpeed,
                    const S3PutObjectHandler *handler, void *callbackData);
 
 
@@ -2097,6 +2098,7 @@ void S3_put_object(const S3BucketContext *bucketContext, const char *key,
  *        request to, and does not perform the request immediately.  If NULL,
  *        performs the request immediately and synchronously.
  * @param timeoutMs if not 0 contains total request timeout in milliseconds
+ * @param maxUploadSpeed if not 0, set the max upload speed of the request in byte / sec
  * @param handler gives the callbacks to call as the request is processed and
  *        completed
  * @param callbackData will be passed in as the callbackData parameter to
@@ -2108,7 +2110,7 @@ void S3_copy_object(const S3BucketContext *bucketContext,
                     const S3PutProperties *putProperties,
                     int64_t *lastModifiedReturn, int eTagReturnSize,
                     char *eTagReturn, S3RequestContext *requestContext,
-                    int timeoutMs,
+                    int timeoutMs, int maxUploadSpeed,
                     const S3ResponseHandler *handler, void *callbackData);
 
 
@@ -2148,6 +2150,7 @@ void S3_copy_object(const S3BucketContext *bucketContext,
  *        request to, and does not perform the request immediately.  If NULL,
  *        performs the request immediately and synchronously.
  * @param timeoutMs if not 0 contains total request timeout in milliseconds
+ * @param maxUploadSpeed if not 0, set the max upload speed of the request in byte / sec
  * @param handler gives the callbacks to call as the request is processed and
  *        completed
  * @param callbackData will be passed in as the callbackData parameter to
@@ -2161,7 +2164,7 @@ void S3_copy_object_range(const S3BucketContext *bucketContext,
                           const S3PutProperties *putProperties,
                           int64_t *lastModifiedReturn, int eTagReturnSize,
                           char *eTagReturn, S3RequestContext *requestContext,
-                          int timeoutMs,
+                          int timeoutMs, int maxUploadSpeed,
                           const S3ResponseHandler *handler, void *callbackData);
 
 

--- a/inc/libs3.h
+++ b/inc/libs3.h
@@ -223,7 +223,11 @@ extern "C" {
  * basis by calling S3_set_request_context_verify_peer).
  */
 #define S3_INIT_VERIFY_PEER                2
-
+/**
+ * This constant is used by the S3_initialize() function, it is used to disable
+ * the underlying SSL library.  This is useful for testing and debugging.
+ */
+#define S3_INIT_DONT_USE_SSL                4
 
 /**
  * This convenience constant is used by the S3_initialize() function to

--- a/inc/request.h
+++ b/inc/request.h
@@ -116,6 +116,9 @@ typedef struct RequestParams
     // Request timeout. If 0, no timeout will be enforced
     int timeoutMs;
 
+    // Max upload speed. If 0, no limit will be applied. The speed is in byte / sec
+    int maxUploadSpeed;
+
     // Data passed to S3SetupCurlCallbackEx
     void *curlCallbackData;
 } RequestParams;

--- a/src/bucket.cpp
+++ b/src/bucket.cpp
@@ -168,6 +168,7 @@ void S3_test_bucket(S3Protocol protocol, S3UriStyle uriStyle,
         &testBucketCompleteCallback,                  // completeCallback
         tbData,                                       // callbackData
         timeoutMs,                                    // timeoutMs
+        0,                                            // maxUploadSpeed
         callbackData                                  // curlCallbackData
     };
 
@@ -324,6 +325,7 @@ void S3_create_bucket(S3Protocol protocol, const char *accessKeyId,
         &createBucketCompleteCallback,                // completeCallback
         cbData,                                       // callbackData
         timeoutMs,                                    // timeoutMs
+        0,                                            // maxUploadSpeed
         callbackData                                  // curlCallbackData
     };
 
@@ -413,6 +415,7 @@ void S3_delete_bucket(S3Protocol protocol, S3UriStyle uriStyle,
         &deleteBucketCompleteCallback,                // completeCallback
         dbData,                                       // callbackData
         timeoutMs,                                    // timeoutMs
+        0,                                            // maxUploadSpeed
         callbackData                                  // curlCallbackData
     };
 
@@ -778,6 +781,7 @@ void S3_list_bucket(const S3BucketContext *bucketContext, const char *prefix,
         &listBucketCompleteCallback,                  // completeCallback
         lbData,                                       // callbackData
         timeoutMs,                                    // timeoutMs
+        0,                                            // maxUploadSpeed
         callbackData                                  // curlCallbackData
     };
 

--- a/src/bucket_metadata.c
+++ b/src/bucket_metadata.c
@@ -161,6 +161,7 @@ void S3_get_acl(const S3BucketContext *bucketContext, const char *key,
         &getAclCompleteCallback,                      // completeCallback
         gaData,                                       // callbackData
         timeoutMs,                                    // timeoutMs
+        0,                                            // maxUploadSpeed
         callbackData                                  // curlCallbackData
     };
 
@@ -368,6 +369,7 @@ void S3_set_acl(const S3BucketContext *bucketContext, const char *key,
         &setXmlCompleteCallback,                      // completeCallback
         data,                                         // callbackData
         timeoutMs,                                    // timeoutMs
+        0,                                            // maxUploadSpeed
         callbackData                                  // curlCallbackData
     };
 
@@ -477,6 +479,7 @@ void S3_get_lifecycle(const S3BucketContext *bucketContext,
         &getLifecycleCompleteCallback,                // completeCallback
         gaData,                                       // callbackData
         timeoutMs,                                    // timeoutMs
+        0,                                            // maxUploadSpeed
         callbackData                                  // curlCallbackData
     };
 
@@ -602,6 +605,7 @@ void S3_set_lifecycle(const S3BucketContext *bucketContext,
         &setXmlCompleteCallback,                      // completeCallback
         data,                                         // callbackData
         timeoutMs,                                    // timeoutMs
+        0,                                            // maxUploadSpeed
         callbackData                                  // curlCallbackData
     };
 

--- a/src/multipart.cpp
+++ b/src/multipart.cpp
@@ -103,8 +103,8 @@ static S3Status initialMultipartXmlCallback(const char *elementPath,
     return S3StatusOK;
 }
 
-static S3Status InitialMultipartPropertiesCallback(const S3ResponseProperties *properties, 
-                                                   void *callbackData) 
+static S3Status InitialMultipartPropertiesCallback(const S3ResponseProperties *properties,
+                                                   void *callbackData)
 {
   InitialMultipartData *mdata = (InitialMultipartData *)callbackData;
   return mdata->handler->responseHandler.propertiesCallback(properties, mdata->userdata);
@@ -153,6 +153,7 @@ void S3_initiate_multipart(S3BucketContext *bucketContext, const char *key,
         InitialMultipartCompleteCallback,             // completeCallback
         mdata,                                        // callbackData
         timeoutMs,                                    // timeoutMs
+        0,                                            // maxUploadSpeed
         callbackData                                  // curlCallbackData
     };
 
@@ -196,6 +197,7 @@ void S3_abort_multipart_upload(S3BucketContext *bucketContext, const char *key,
         AbortMultipartUploadCompleteCallback,         // completeCallback
         0,                                            // callbackData
         timeoutMs,                                    // timeoutMs
+        0,                                            // maxUploadSpeed
         0                                             // curlCallbackData
     };
 
@@ -246,6 +248,7 @@ void S3_upload_part(S3BucketContext *bucketContext, const char *key,
         handler->responseHandler.completeCallback,    // completeCallback
         callbackData,                                 // callbackData
         timeoutMs,                                    // timeoutMs
+        0,                                            // maxUploadSpeed
         callbackData                                  // curlCallbackData
     };
 
@@ -387,6 +390,7 @@ void S3_complete_multipart_upload(S3BucketContext *bucketContext,
         commitMultipartCompleteCallback,              // completeCallback
         data,                                         // callbackData
         timeoutMs,                                    // timeoutMs
+        0,                                             // maxUploadSpeed
         callbackData                                  // curlCallbackData
     };
 
@@ -983,6 +987,7 @@ void S3_list_multipart_uploads(S3BucketContext *bucketContext,
             &listMultipartCompleteCallback,          // completeCallback
             lmData,                                  // callbackData
             timeoutMs,                               // timeoutMs
+            0,                                       // maxUploadSpeed
             callbackData                             // curlCallbackData
         };
 
@@ -1108,6 +1113,7 @@ void S3_list_parts(S3BucketContext *bucketContext, const char *key,
             &listPartsCompleteCallback,              // completeCallback
             lpData,                                  // callbackData
             timeoutMs,                               // timeoutMs
+            0,                                       // maxUploadSpeed
             callbackData                             // curlCallbackData
         };
 

--- a/src/object.c
+++ b/src/object.c
@@ -43,6 +43,7 @@ void S3_put_object(const S3BucketContext *bucketContext, const char *key,
                    const S3PutProperties *putProperties,
                    S3RequestContext *requestContext,
                    int timeoutMs,
+                   int maxUploadSpeed,
                    const S3PutObjectHandler *handler, void *callbackData)
 {
     // Set up the RequestParams
@@ -73,6 +74,7 @@ void S3_put_object(const S3BucketContext *bucketContext, const char *key,
         handler->responseHandler.completeCallback,    // completeCallback
         callbackData,                                 // callbackData
         timeoutMs,                                    // timeoutMs
+        maxUploadSpeed,                               // maxUploadSpeed
         callbackData                                  // curlCallbackData
     };
 
@@ -182,7 +184,7 @@ void S3_copy_object(const S3BucketContext *bucketContext, const char *key,
                     const S3PutProperties *putProperties,
                     int64_t *lastModifiedReturn, int eTagReturnSize,
                     char *eTagReturn, S3RequestContext *requestContext,
-                    int timeoutMs,
+                    int timeoutMs, int maxUploadSpeed,
                     const S3ResponseHandler *handler, void *callbackData)
 {
     /* Use the range copier with 0 length */
@@ -193,7 +195,7 @@ void S3_copy_object(const S3BucketContext *bucketContext, const char *key,
                          putProperties,
                          lastModifiedReturn, eTagReturnSize,
                          eTagReturn, requestContext,
-                         timeoutMs,
+                         timeoutMs, maxUploadSpeed,
                          handler, callbackData);
 }
 
@@ -206,7 +208,7 @@ void S3_copy_object_range(const S3BucketContext *bucketContext, const char *key,
                           const S3PutProperties *putProperties,
                           int64_t *lastModifiedReturn, int eTagReturnSize,
                           char *eTagReturn, S3RequestContext *requestContext,
-                          int timeoutMs,
+                          int timeoutMs, int maxUploadSpeed,
                           const S3ResponseHandler *handler, void *callbackData)
 {
     // Create the callback data
@@ -269,6 +271,7 @@ void S3_copy_object_range(const S3BucketContext *bucketContext, const char *key,
         &copyObjectCompleteCallback,                  // completeCallback
         data,                                         // callbackData
         timeoutMs,                                    // timeoutMs
+        maxUploadSpeed,                               // maxUploadSpeed
         callbackData                                  // curlCallbackData
     };
 
@@ -314,6 +317,7 @@ void S3_get_object(const S3BucketContext *bucketContext, const char *key,
         handler->responseHandler.completeCallback,    // completeCallback
         callbackData,                                 // callbackData
         timeoutMs,                                    // timeoutMs
+        0,                                            // int maxUploadSpeed
         callbackData                                  // curlCallbackData
     };
 
@@ -357,6 +361,7 @@ void S3_head_object(const S3BucketContext *bucketContext, const char *key,
         handler->completeCallback,                    // completeCallback
         callbackData,                                 // callbackData
         timeoutMs,                                    // timeoutMs
+        0,                                            // int maxUploadSpeed
         callbackData                                  // curlCallbackData
     };
 
@@ -400,6 +405,7 @@ void S3_delete_object(const S3BucketContext *bucketContext, const char *key,
         handler->completeCallback,                    // completeCallback
         callbackData,                                 // callbackData
         timeoutMs,                                    // timeoutMs
+        0,                                            // int maxUploadSpeed
         callbackData                                  // curlCallbackData
     };
 

--- a/src/request.cpp
+++ b/src/request.cpp
@@ -57,7 +57,7 @@
 //#define SIGNATURE_DEBUG
 
 extern "C" {
-  
+
 static int verifyPeer;
 
 static char userAgentG[USER_AGENT_SIZE];
@@ -313,7 +313,7 @@ static S3Status append_amz_header(RequestComputedValues *values,
     values->amzHeaders[values->amzHeadersCount++] = &(values->amzHeadersRaw[rawPos]);
 
     const char *headerStr = headerName;
-    
+
     char headerNameWithPrefix[S3_MAX_METADATA_SIZE - sizeof(": v")];
     if (addPrefix) {
         snprintf(headerNameWithPrefix, sizeof(headerNameWithPrefix),
@@ -1252,6 +1252,9 @@ static S3Status setup_curl(Request *request,
         curl_easy_setopt_safe(CURLOPT_TIMEOUT_MS, params->timeoutMs);
     }
 
+    if (params->maxUploadSpeed > 0){
+        curl_easy_setopt_safe(CURLOPT_MAX_SEND_SPEED_LARGE, params->maxUploadSpeed);
+    }
 
     // Append standard headers
 #define append_standard_header(fieldName)                               \
@@ -1788,7 +1791,7 @@ S3Status S3_generate_authenticated_query_string
     RequestParams params =
     { http_request_method_to_type(httpMethod), *bucketContext, key, NULL,
         resource,
-        NULL, NULL, NULL, 0, 0, NULL, NULL, NULL, 0, NULL, NULL, NULL, 0, NULL};
+        NULL, NULL, NULL, 0, 0, NULL, NULL, NULL, 0, NULL, NULL, NULL, 0, 0, NULL};
 
     RequestComputedValues computed;
     S3Status status = setup_request(&params, &computed, 1);

--- a/src/request.cpp
+++ b/src/request.cpp
@@ -1480,8 +1480,9 @@ static void request_release(Request *request)
 S3Status request_api_initialize(const char *userAgentInfo, int flags,
                                 const char *defaultHostName)
 {
-    if (curl_global_init(CURL_GLOBAL_ALL &
-                         ~((flags & S3_INIT_WINSOCK) ? 0 : CURL_GLOBAL_WIN32))
+    long curlFlags = CURL_GLOBAL_ALL & ~((flags & S3_INIT_WINSOCK) ? 0 : CURL_GLOBAL_WIN32);
+    curlFlags &= ~((flags & S3_INIT_DONT_USE_SSL) ? CURL_GLOBAL_SSL : 0);
+    if (curl_global_init(curlFlags)
         != CURLE_OK) {
         return S3StatusInternalError;
     }

--- a/src/s3.c
+++ b/src/s3.c
@@ -2415,7 +2415,7 @@ static void put_object(int argc, char **argv, int optindex,
 
         do {
             S3_put_object(&bucketContext, key, contentLength, &putProperties, 0,
-                          0, &putObjectHandler, &data);
+                          0, 0, &putObjectHandler, &data);
         } while (S3_status_is_retryable(statusG) && should_retry());
 
         if (data.infile) {
@@ -2538,7 +2538,7 @@ upload:
                                          &putProperties,
                                          &lastModified, 512 /*TBD - magic # */,
                                          manager.etags[seq-1], 0,
-                                         timeoutMsG,
+                                         timeoutMsG, 0,
                                          &copyResponseHandler, 0);
                 } else {
                     S3_upload_part(&bucketContext, key, &putProperties,
@@ -2840,7 +2840,7 @@ static void copy_object(int argc, char **argv, int optindex)
         S3_copy_object(&bucketContext, sourceKey, destinationBucketName,
                        destinationKey, anyPropertiesSet ? &putProperties : 0,
                        &lastModified, sizeof(eTag), eTag, 0,
-                       timeoutMsG,
+                       timeoutMsG, 0,
                        &responseHandler, 0);
     } while (S3_status_is_retryable(statusG) && should_retry());
 

--- a/src/service.c
+++ b/src/service.c
@@ -193,6 +193,7 @@ void S3_list_service(S3Protocol protocol, const char *accessKeyId,
         &completeCallback,                            // completeCallback
         data,                                         // callbackData
         timeoutMs,                                    // timeoutMs
+        0,                                            // maxUploadSpeed
         callbackData                                  // curlCallbackData
     };
 

--- a/src/service_access_logging.c
+++ b/src/service_access_logging.c
@@ -354,6 +354,7 @@ void S3_get_server_access_logging(const S3BucketContext *bucketContext,
         &getBlsCompleteCallback,                      // completeCallback
         gsData,                                       // callbackData
         timeoutMs,                                    // timeoutMs
+        0,                                            // maxUploadSpeed
         callbackData                                  // curlCallbackData
     };
 
@@ -563,6 +564,7 @@ void S3_set_server_access_logging(const S3BucketContext *bucketContext,
         &setSalCompleteCallback,                      // completeCallback
         data,                                         // callbackData
         timeoutMs,                                    // timeoutMs
+        0,                                            // maxUploadSpeed
         callbackData                                  // curlCallbackData
     };
 


### PR DESCRIPTION
Sometimes, to use the whole network throughput isn't the best choice if copy between buckets or put object into the s3.

The underling lib curl allows limiting the upload speed.

From now, this upload limit can be set for put and copy methods in the library part.